### PR TITLE
(gh-20) Download with curl --fail instead of --fail-with-body

### DIFF
--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -13,8 +13,6 @@ env:
   # Environment variables needed when running the task install scripts
   # manually.
   PT__installdir: ${{ github.workspace }}
-  PT_apt_source: "https://apt.voxpupuli.org"
-  PT_yum_source: "https://yum.voxpupuli.org"
 
 jobs:
   shellcheck:

--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -46,8 +46,7 @@ jobs:
       - name: Run openvox-agent install task
         run: bolt task run openvox_bootstrap::install --targets localhost --run-as root
       - name: Verify openvox-agent is installed
-        run: |-
-          [[ "$(/opt/puppetlabs/bin/puppet --version)" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]
+        run: bolt task run openvox_bootstrap::check --targets localhost --run-as root
       - name: Verify idempotency
         run: bolt task run openvox_bootstrap::install --targets localhost --run-as root
 
@@ -80,7 +79,10 @@ jobs:
           PT_collection: openvox8
         run: ./openvox_bootstrap/tasks/install_linux.sh
       - name: Verify openvox-agent is installed
-        run: /opt/puppetlabs/bin/puppet --version | grep -E '8\.[0-9]+'
+        env:
+          PT_version: '8'
+          PT_test: 'gt'
+        run: ./openvox_bootstrap/tasks/check_linux.sh
       - name: Verify idempotency
         env:
           PT_collection: openvox8
@@ -110,7 +112,9 @@ jobs:
           PT_version: "8.14.0"
         run: ./openvox_bootstrap/tasks/install_linux.sh
       - name: Verify openvox-agent is installed
-        run: /opt/puppetlabs/bin/puppet --version | grep '8.14.0'
+        env:
+          PT_version: "8.14.0"
+        run: ./openvox_bootstrap/tasks/check_linux.sh
       - name: Verify idempotency
         env:
           PT_version: "8.14.0"

--- a/.github/workflows/pr_testing_install_build_artifact.yaml
+++ b/.github/workflows/pr_testing_install_build_artifact.yaml
@@ -29,8 +29,7 @@ jobs:
       - name: Run openvox-agent install task
         run: bolt task run openvox_bootstrap::install_build_artifact version=8.15.0 --targets localhost --run-as root
       - name: Verify openvox-agent is installed
-        run: |-
-          [[ "$(/opt/puppetlabs/bin/puppet --version)" = "8.15.0" ]]
+        run: bolt task run openvox_bootstrap::check version=8.15.0 --targets localhost --run-as root
       - name: Verify idempotency
         run: bolt task run openvox_bootstrap::install_build_artifact version=8.15.0 --targets localhost --run-as root
 
@@ -64,8 +63,10 @@ jobs:
         run: ./openvox_bootstrap/tasks/install_build_artifact_linux.sh
       - name: Verify openvox-agent is installed
         shell: bash
-        run: |-
-          [[ "$(/opt/puppetlabs/bin/puppet --version)" = "8.15.0" ]]
+        env:
+          PT__installdir: ${{ github.workspace }}
+          PT_version: "8.15.0"
+        run: ./openvox_bootstrap/tasks/check_linux.sh
       - name: Verify idempotency
         env:
           PT__installdir: ${{ github.workspace }}

--- a/.github/workflows/pr_testing_with_nested_vms.yml
+++ b/.github/workflows/pr_testing_with_nested_vms.yml
@@ -1,0 +1,68 @@
+---
+name: 'PR Testing with Nested VMs'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-install-task:
+    strategy:
+      matrix:
+        os:
+          - [almalinux, '8']
+          - [almalinux, '9']
+          - [debian, '10']
+          - [debian, '11']
+          - [debian, '12']
+          - [debian, '13', 'amd64', 'daily-latest']
+          - [rocky, '8']
+          - [rocky, '9']
+          - [ubuntu, '18.04']
+          - [ubuntu, '20.04']
+          - [ubuntu, '22.04']
+          - [ubuntu, '24.04']
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - id: install-bolt
+        uses: ./.github/actions/bolt
+        with:
+          os-codename: jammy
+      - id: vm-cluster
+        uses: jpartlow/nested_vms@v1
+        with:
+          os: ${{ matrix.os[0] }}
+          os-version: ${{ matrix.os[1] }}
+          os-arch: ${{ matrix.os[2] || 'x86_64' }}
+          image_version: ${{ matrix.os[3] }}
+          host-root-access: true
+          ruby-version: '3.3'
+          install-openvox: false
+          # Note: the cpu_mode is set to host-model for the sake of
+          # el-9 which expects at least x86_64-2 arch. This depends on
+          # the runner's architecture being sufficient, and there is
+          # probably a better way to get this set on the libvirt
+          # domain instead.
+          vms: |-
+            [
+              {
+                "role": "agent",
+                "count": 1,
+                "cpus": 2,
+                "mem_mb": 4096,
+                "cpu_mode": "host-model"
+              }
+            ]
+      - name: Run openvox_bootstrap::install task on nested vm
+        run: |-
+          bolt task run openvox_bootstrap::install --inventory kvm_automation_tooling/terraform/instances/inventory.test.yaml --targets test-agent-1
+      - name: Verify openvox-agent is installed
+        run: |-
+          bolt command run \
+            --inventory kvm_automation_tooling/terraform/instances/inventory.test.yaml --targets test-agent-1 \
+            '[[ "$(/opt/puppetlabs/bin/puppet --version)" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]'

--- a/.github/workflows/pr_testing_with_nested_vms.yml
+++ b/.github/workflows/pr_testing_with_nested_vms.yml
@@ -63,6 +63,4 @@ jobs:
           bolt task run openvox_bootstrap::install --inventory kvm_automation_tooling/terraform/instances/inventory.test.yaml --targets test-agent-1
       - name: Verify openvox-agent is installed
         run: |-
-          bolt command run \
-            --inventory kvm_automation_tooling/terraform/instances/inventory.test.yaml --targets test-agent-1 \
-            '[[ "$(/opt/puppetlabs/bin/puppet --version)" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]'
+          bolt task run openvox_bootstrap::check version=8 test=gt --inventory kvm_automation_tooling/terraform/instances/inventory.test.yaml --targets test-agent-1

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,10 +6,31 @@
 
 ### Tasks
 
+* [`check`](#check): Check whether a Puppet(tm) implementation is installed. Optionally checks the version.
 * [`install`](#install): Installs an openvox package. By default, this will be the latest openvox-agent from the latest collection.
 * [`install_build_artifact`](#install_build_artifact): Downloads and installs a package directly from the openvox build artifact server.
 
 ## Tasks
+
+### <a name="check"></a>`check`
+
+Check whether a Puppet(tm) implementation is installed. Optionally checks the version.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `version`
+
+Data type: `Optional[String]`
+
+The version of the implementation to check. To check if version meets a minimum, set test to 'ge' and version to x, x.y or x.y.z
+
+##### `test`
+
+Data type: `Enum['eq', 'lt', 'le', 'gt', 'ge']`
+
+Version comparison operator.
 
 ### <a name="install"></a>`install`
 

--- a/files/common.sh
+++ b/files/common.sh
@@ -1,8 +1,7 @@
 #! /usr/bin/env bash
 
 # PT_* variables are set by Bolt.
-# shellcheck disable=SC2154
-installdir=$PT__installdir
+declare PT__installdir
 
 tempdir=$(mktemp -d)
 trap 'rm -rf $tempdir' EXIT
@@ -210,7 +209,7 @@ set_os_family() {
 #   $os_major_version
 #   $os_family
 set_platform_globals() {
-  local facts="${installdir}/facts/tasks/bash.sh"
+  local facts="${PT__installdir}/facts/tasks/bash.sh"
   if [ -e "${facts}" ]; then
     platform=$(bash "${facts}" platform)
     os_full_version=$(bash "${facts}" release)

--- a/files/common.sh
+++ b/files/common.sh
@@ -143,7 +143,7 @@ download() {
   if exists 'wget'; then
     exec_and_capture wget -O "${_file}" "${_url}"
   elif exists 'curl'; then
-    exec_and_capture curl --fail-with-body -sSL -o "${_file}" "${_url}"
+    exec_and_capture curl --fail -sSL -o "${_file}" "${_url}"
   else
     fail "Unable to download ${_url}. Neither wget nor curl are installed."
   fi

--- a/spec/tasks/check_spec.rb
+++ b/spec/tasks/check_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../tasks/check'
+
+describe 'openvox_bootstrap::check' do
+  before do
+    allow(OpenvoxBootstrap::Check).to receive(:puppet_version).and_return('8.0.0')
+  end
+
+  describe '.run' do
+    let(:input) do
+      {
+        version: nil
+      }
+    end
+    let(:expected_output) do
+      {
+        puppet_version: '8.0.0',
+        valid: true
+      }
+    end
+
+    def validate_task_run(input:, expected: {}, code: 0)
+      old_stdin = $stdin
+      $stdin = StringIO.new(input.to_json)
+      old_stdout = $stdout
+      $stdout = StringIO.new
+
+      begin
+        OpenvoxBootstrap::Check.run
+      rescue SystemExit => e
+        expect(e.status).to eq(code)
+      end
+
+      output = JSON.parse($stdout.string, symbolize_names: true)
+      expect(output).to eq(expected)
+    ensure
+      $stdin = old_stdin
+      $stdout = old_stdout
+    end
+
+    it 'raises for empty input' do
+      expect do
+        validate_task_run(input: nil)
+      end.to raise_error(ArgumentError)
+    end
+
+    it 'returns version without test if given no args' do
+      validate_task_run(input: input, expected: expected_output)
+    end
+
+    context 'testing valid version' do
+      it 'returns successfully' do
+        input[:version] = '8.0.0'
+
+        expected_output[:test] = 'eq'
+        expected_output[:test_version] = '8.0.0'
+
+        validate_task_run(input: input, expected: expected_output)
+      end
+    end
+
+    context 'testing invalid version' do
+      it 'returns non-zero' do
+        input[:version] = '8.1.0'
+        input[:test] = 'gt'
+
+        expected_output[:valid] = false
+        expected_output[:test] = 'gt'
+        expected_output[:test_version] = '8.1.0'
+
+        validate_task_run(input: input, expected: expected_output, code: 1)
+      end
+    end
+  end
+
+  describe '#task' do
+    let(:check) { OpenvoxBootstrap::Check.new }
+
+    context 'eq' do
+      it 'returns true for equal versions' do
+        expect(check.task(version: '8.0.0')).to(
+          eq(
+            {
+              puppet_version: '8.0.0',
+              valid: true,
+              test: 'eq',
+              test_version: '8.0.0'
+            }
+          )
+        )
+      end
+
+      it 'returns false for unequal versions' do
+        expect(check.task(version: '8.0.1')).to(
+          eq(
+            {
+              puppet_version: '8.0.0',
+              valid: false,
+              test: 'eq',
+              test_version: '8.0.1'
+            }
+          )
+        )
+      end
+    end
+
+    context 'ge' do
+      it 'returns true for greater than versions' do
+        expect(check.task(version: '7.0.0', test: 'ge')).to(
+          eq(
+            {
+              puppet_version: '8.0.0',
+              valid: true,
+              test: 'ge',
+              test_version: '7.0.0'
+            }
+          )
+        )
+      end
+
+      it 'returns true for equal versions' do
+        expect(check.task(version: '8.0.0', test: 'ge')).to(include(valid: true))
+      end
+
+      it 'returns false for less than versions' do
+        expect(check.task(version: '9.0.0', test: 'ge')).to(
+          eq(
+            {
+              puppet_version: '8.0.0',
+              valid: false,
+              test: 'ge',
+              test_version: '9.0.0'
+            }
+          )
+        )
+      end
+    end
+
+    context 'gt' do
+      it 'is valid for greater than versions' do
+        expect(check.task(version: '7.0.0', test: 'gt')).to(include(valid: true))
+      end
+
+      it 'is invalid for equal versions or less than versions' do
+        expect(check.task(version: '8.0.0', test: 'gt')).to(include(valid: false))
+        expect(check.task(version: '8.0.1', test: 'gt')).to(include(valid: false))
+      end
+    end
+
+    context 'lt' do
+      it 'is valid for less than versions' do
+        expect(check.task(version: '8.0.1', test: 'lt')).to(include(valid: true))
+      end
+
+      it 'is invalid for equal versions or greater than versions' do
+        expect(check.task(version: '8.0.0', test: 'lt')).to(include(valid: false))
+        expect(check.task(version: '7.0.0', test: 'lt')).to(include(valid: false))
+      end
+    end
+
+    context 'le' do
+      it 'is valid for less than or equal versions' do
+        expect(check.task(version: '9.0.0', test: 'le')).to(include(valid: true))
+        expect(check.task(version: '8.0.0', test: 'le')).to(include(valid: true))
+      end
+
+      it 'is invalid for greater than versions' do
+        expect(check.task(version: '7.0.0', test: 'le')).to(include(valid: false))
+      end
+    end
+  end
+end

--- a/spec/unit/bash/common_sh_spec.rb
+++ b/spec/unit/bash/common_sh_spec.rb
@@ -247,8 +247,7 @@ describe 'files/common.sh' do
         expect(status.success?).to be(false)
         expect(output).to include('Executing: curl ')
         expect(output).to include('The requested URL returned error: 404')
-        file = File.read("#{tmpdir}/file")
-        expect(file).to include('404 Not Found')
+        expect(File.exist?("#{tmpdir}/file")).to be(false)
       end
     end
   end

--- a/tasks/check.json
+++ b/tasks/check.json
@@ -1,0 +1,29 @@
+{
+  "description": "Check whether a Puppet(tm) implementation is installed. Optionally checks the version.",
+  "parameters": {
+    "version": {
+      "description": "The version of the implementation to check. To check if version meets a minimum, set test to 'ge' and version to x, x.y or x.y.z",
+      "type": "Optional[String]"
+    },
+    "test": {
+      "description": "Version comparison operator.",
+      "type": "Enum['eq', 'lt', 'le', 'gt', 'ge']",
+      "default": "eq"
+    }
+  },
+  "implementations": [
+    {
+      "name": "check.rb",
+      "input_method": "stdin",
+      "requirements": ["puppet-agent"]
+    },
+    {
+      "name": "check_linux.sh",
+      "input_method": "environment",
+      "requirements": ["shell"],
+      "files": [
+        "openvox_bootstrap/tasks/check.rb"
+      ]
+    }
+  ]
+}

--- a/tasks/check.rb
+++ b/tasks/check.rb
@@ -1,0 +1,71 @@
+#! /opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+
+module OpenvoxBootstrap
+  class Check
+    # Get the Puppet version from the installed Puppet library.
+    #
+    # "require 'puppet/version'" can be fooled by the Ruby environment
+    # if the gem is installed. For example:
+    #
+    #   bolt task run openvox_bootstrap::check --targets localhost
+    #
+    # will be executed using the bolt package's Ruby environment,
+    # which includes a puppet gem that will mostly likely be out of
+    # sync with the installed Puppet version.
+    def self.puppet_version
+      require '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/version'
+      Puppet.version
+    end
+
+    # Run the task and print the result as JSON.
+    def self.run
+      params = JSON.parse($stdin.read)
+      raise(ArgumentError, <<~ERR) unless params.is_a?(Hash)
+        Expected a Hash, got #{params.class}: #{params.inspect}
+      ERR
+
+      params.transform_keys!(&:to_sym)
+      # Clean out empty params so that task defaults are used.
+      params.delete_if { |_, v| v.nil? || v == '' }
+
+      result = Check.new.task(**params)
+      puts JSON.pretty_generate(result)
+      result[:valid] ? exit(0) : exit(1)
+    end
+
+    def task(version: nil, test: 'eq', **_kwargs)
+      puppet_version = Gem::Version.new(OpenvoxBootstrap::Check.puppet_version)
+      result = {
+        puppet_version: puppet_version.to_s,
+      }
+      result[:valid] = if version.nil? || version.empty?
+                         true
+                       else
+                         test_version = Gem::Version.new(version)
+                         result[:test] = test
+                         result[:test_version] = version
+                         case test
+                         when 'eq'
+                           puppet_version == test_version
+                         when 'lt'
+                           puppet_version < test_version
+                         when 'le'
+                           puppet_version <= test_version
+                         when 'gt'
+                           puppet_version > test_version
+                         when 'ge'
+                           puppet_version >= test_version
+                         else
+                           raise ArgumentError, "Unknown test: '#{test}'"
+                         end
+                       end
+
+      result
+    end
+  end
+end
+
+OpenvoxBootstrap::Check.run if __FILE__ == $PROGRAM_NAME

--- a/tasks/check_linux.sh
+++ b/tasks/check_linux.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+set -e
+
+declare PT__installdir
+declare PT_version
+declare PT_test
+
+bindir='/opt/puppetlabs/puppet/bin'
+
+if ! [ -f "${bindir}/puppet" ]; then
+  echo "Error: No puppet binary found at '${bindir}/puppet'. Is the package installed?"
+  exit 1
+fi
+
+"${bindir}/ruby" "${PT__installdir}/openvox_bootstrap/tasks/check.rb" <<JSON
+{
+  "version": "${PT_version}",
+  "test": "${PT_test}"
+}
+JSON

--- a/tasks/install_build_artifact_linux.sh
+++ b/tasks/install_build_artifact_linux.sh
@@ -3,17 +3,13 @@
 set -e
 
 # PT_* variables are set by Bolt.
-# shellcheck disable=SC2154
-installdir=$PT__installdir
-# shellcheck disable=SC2154
-version=${PT_version}
-# shellcheck disable=SC2154
-package=${PT_package:-'openvox-agent'}
-# shellcheck disable=SC2154
-artifacts_source=${PT_artifacts_source:-'https://artifacts.voxpupuli.org'}
+declare PT__installdir
+version=${PT_version:-}
+package=${PT_package:-openvox-agent}
+artifacts_source=${PT_artifacts_source:-https://artifacts.voxpupuli.org}
 
 # shellcheck source=files/common.sh
-source "${installdir}/openvox_bootstrap/files/common.sh"
+source "${PT__installdir}/openvox_bootstrap/files/common.sh"
 
 # Lookup the cpu architecture and set it as cpu_arch.
 # Translates x86_64 to amd64 and aarch64 to arm64 for debian/ubuntu.

--- a/tasks/install_linux.sh
+++ b/tasks/install_linux.sh
@@ -3,21 +3,15 @@
 set -e
 
 # PT_* variables are set by Bolt.
-# shellcheck disable=SC2154
-installdir=$PT__installdir
-# shellcheck disable=SC2154
-package=${PT_package:-'openvox-agent'}
-# shellcheck disable=SC2154
-version=${PT_version:-'latest'}
-# shellcheck disable=SC2154
-collection=${PT_collection:-'openvox8'}
-# shellcheck disable=SC2154
-yum_source=${PT_yum_source:-'https://yum.voxpupuli.org'}
-# shellcheck disable=SC2154
-apt_source=${PT_apt_source:-'https://apt.voxpupuli.org'}
+declare PT__installdir
+package=${PT_package:-openvox-agent}
+version=${PT_version:-latest}
+collection=${PT_collection:-openvox8}
+yum_source=${PT_yum_source:-https://yum.voxpupuli.org}
+apt_source=${PT_apt_source:-https://apt.voxpupuli.org}
 
 # shellcheck source=files/common.sh
-source "${installdir}/openvox_bootstrap/files/common.sh"
+source "${PT__installdir}/openvox_bootstrap/files/common.sh"
 
 # Based on platform family set:
 #   repository - the package repository to download from


### PR DESCRIPTION
#### Pull Request (PR) description

The --fail-with-body parameter was introduced into curl in in 7.76.0 - March 31 2021 (https://curl.se/changes.html). Older vms we are still testing on may have curls predating this version. For example, the rocky8/alma8 vm images have curl 7.61.1 - September 5 2018.

Switching the --fail provides basically the same semantics, but without capturing the full response body in the file. Not trying to scrape the respone, atm, though, so this should be fine.

* adds a workflow to test with nested_vms action to validate
* adds a check task to make validating that puppet is installed uniform
* cleans up some of the input parameter handling in the shell scripts

#### This Pull Request (PR) fixes the following issues

Fixes #20 