### PR TITLE
(maint) Drop debian-10 from testing matrix

### DIFF
--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -56,7 +56,6 @@ jobs:
           - almalinux:9
           - rockylinux:8
           - rockylinux:9
-          - debian:10
           - debian:11
           - debian:12
           - fedora:42

--- a/.github/workflows/pr_testing_install_build_artifact.yaml
+++ b/.github/workflows/pr_testing_install_build_artifact.yaml
@@ -41,7 +41,6 @@ jobs:
           - almalinux:9
           - rockylinux:8
           - rockylinux:9
-          - debian:10
           - debian:11
           - debian:12
           - fedora:42

--- a/.github/workflows/pr_testing_with_nested_vms.yml
+++ b/.github/workflows/pr_testing_with_nested_vms.yml
@@ -16,7 +16,6 @@ jobs:
         os:
           - [almalinux, '8']
           - [almalinux, '9']
-          - [debian, '10']
           - [debian, '11']
           - [debian, '12']
           - [debian, '13', 'amd64', 'daily-latest']


### PR DESCRIPTION
#### Pull Request (PR) description

Debian 10 was eol last year. Packages have now been dropped from the main deb.debian.org mirrors and are now available only from archive.debian.org, so the images no longer work correctly.

#### This Pull Request (PR) fixes the following issues

Removes failing debian-10 job from gha workflows.