### PR TITLE
(gha) Do not fail fast when running the nested vms tests

### DIFF
--- a/.github/workflows/pr_testing_with_nested_vms.yml
+++ b/.github/workflows/pr_testing_with_nested_vms.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   test-install-task:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - [almalinux, '8']


### PR DESCRIPTION
...so that we get a better sense of all the vm state rather than just the first to fail.
