### PR TITLE
(gh-33) Configure openbox_boostrap as a puppet_library bolt plugin

### DIFF
--- a/bolt_plugin.json
+++ b/bolt_plugin.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "puppet_library": { "task": "openvox_bootstrap::install" }
+  }
+}


### PR DESCRIPTION
This is for openvoxproject/openbolt#44 to replace puppet_agent with openvox_bootstrap as the default puppet_library plugin so that apply_prep calls install openvox instead of the perforce agent. The plugin configuration tells bolt what task to execute for this hook, per https://help.puppet.com/bolt/current/topics/writing_plugins.htm#plugin-hooks

#### This Pull Request (PR) fixes the following issues

Implements:
* #33 