### PR TITLE
Allow downgrades using apt when version specified 

### DIFF
--- a/.github/actions/bolt/action.yaml
+++ b/.github/actions/bolt/action.yaml
@@ -3,8 +3,8 @@ name: Install and Prepare Bolt
 description: "Helps with installing Bolt from the Puppet repository on Ubuntu distributions."
 
 inputs:
-  os-codename:
-    description: The Ubuntu codename of the OS to install Bolt on.
+  os-version:
+    description: The version of the Ubuntu OS to install Bolt on.
     required: true
     type: string
 
@@ -14,12 +14,13 @@ runs:
     - name: Install Bolt
       shell: bash
       env:
-        OS_CODENAME: ${{ inputs.os-codename }}
+        APT_REPOSITORY: apt.voxpupuli.org
+        RELEASE_PACKAGE: ${{ format('openvox8-release-ubuntu{0}.deb', inputs.os-version) }}
       run: |-
-        wget https://apt.puppet.com/puppet-tools-release-${OS_CODENAME}.deb
-        sudo dpkg -i puppet-tools-release-${OS_CODENAME}.deb
+        wget https://${APT_REPOSITORY}/${RELEASE_PACKAGE}
+        sudo dpkg -i ${RELEASE_PACKAGE}
         sudo apt update
-        sudo apt install -y puppet-bolt
+        sudo apt install -y openbolt
     - name: Install module dependencies
       shell: bash
       run: bolt module install

--- a/.github/actions/container_task_prep/action.yaml
+++ b/.github/actions/container_task_prep/action.yaml
@@ -5,6 +5,8 @@ description: "Checkouts module dependencies and ensures a wget is installed so t
 runs:
   using: "composite"
   steps:
+    # The basic facts shell script is sourced by install_package
+    # below to set platform globals.
     - uses: actions/checkout@v4
       with:
         repository: puppetlabs/puppetlabs-facts

--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -27,20 +27,17 @@ jobs:
   test-install-task-on-ubuntu:
     strategy:
       matrix:
-        os-details:
-          - os: ubuntu-22.04
-            codename: jammy
-    #      - os: ubuntu-24.04
-    #        codename: noble
-    # Perforce hasn't yet released bolt on 24.04.
-    runs-on: ${{ matrix.os-details.os }}
+        os-version:
+          - 22.04
+          - 24.04
+    runs-on: ${{ format('ubuntu-{0}', matrix.os-version) }}
     needs: shellcheck
     steps:
       - uses: actions/checkout@v4
       - id: install-bolt
         uses: ./.github/actions/bolt
         with:
-          os-codename: ${{ matrix.os-details.codename }}
+          os-version: ${{ matrix.os-version }}
       - name: Run install task for openvox-agent
         run: bolt task run openvox_bootstrap::install --targets localhost --run-as root
       - name: Verify openvox-agent is installed
@@ -59,7 +56,6 @@ jobs:
           - debian:11
           - debian:12
           - fedora:42
-          - ubuntu:24.04
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6
     needs: shellcheck

--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -176,3 +176,45 @@ jobs:
           PT_package: "openvox-server"
           PT_version: "8.8.0"
         run: ./openvox_bootstrap/tasks/install_linux.sh
+
+  test-downgrade:
+    strategy:
+      matrix:
+        image:
+          - almalinux:8
+          - almalinux:9
+          - rockylinux:8
+          - rockylinux:9
+          - debian:11
+          - debian:12
+          - fedora:43
+          # Need to pull in the repo GPG keys for sles
+          #          - registry.suse.com/suse/sle15:15.6
+    needs: shellcheck
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: openvox_bootstrap
+      - id: prep
+        uses: ./openvox_bootstrap/.github/actions/container_task_prep
+      - name: Install latest agent
+        env:
+          PT_collection: openvox8
+        run: ./openvox_bootstrap/tasks/install_linux.sh
+      - name: Verify later openvox-agent is installed
+        env:
+          PT_version: '8.18.0'
+          PT_test: 'gt'
+        run: ./openvox_bootstrap/tasks/check_linux.sh
+      - name: Install older version of agent
+        shell: bash
+        env:
+          PT_collection: openvox8
+          PT_version: "8.18.0"
+        run: ./openvox_bootstrap/tasks/install_linux.sh
+      - name: Verify openvox-agent is downgraded
+        env:
+          PT_version: "8.18.0"
+        run: ./openvox_bootstrap/tasks/check_linux.sh

--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -51,11 +51,14 @@ jobs:
         image:
           - almalinux:8
           - almalinux:9
+          - almalinux:10
           - rockylinux:8
           - rockylinux:9
+          - rockylinux/rockylinux:10
           - debian:11
           - debian:12
-          - fedora:42
+          - debian:13
+          - fedora:43
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6
     needs: shellcheck
@@ -85,9 +88,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - rockylinux:9
-          - fedora:41
-          - debian:12
+          - rockylinux/rockylinux:10
+          - fedora:43
+          - debian:13
           - ubuntu:24.04
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6
@@ -102,25 +105,25 @@ jobs:
         uses: ./openvox_bootstrap/.github/actions/container_task_prep
       - name: Run install task manually for openvox-agent
         env:
-          PT_version: "8.14.0"
+          PT_version: "8.18.0"
         run: ./openvox_bootstrap/tasks/install_linux.sh
       - name: Verify openvox-agent is installed
         env:
-          PT_version: "8.14.0"
+          PT_version: "8.18.0"
         run: ./openvox_bootstrap/tasks/check_linux.sh
       - name: Verify idempotency
         env:
-          PT_version: "8.14.0"
+          PT_version: "8.18.0"
         run: ./openvox_bootstrap/tasks/install_linux.sh
 
   test-install-package:
     strategy:
       matrix:
         image:
-          - rockylinux:9
+          - rockylinux/rockylinux:10
           # openvox-server not currently built for fedora
           #          - fedora:41
-          - debian:12
+          - debian:13
           - ubuntu:24.04
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6
@@ -148,10 +151,10 @@ jobs:
     strategy:
       matrix:
         image:
-          - rockylinux:9
+          - rockylinux/rockylinux:10
           # openvox-server not currently built for fedora
           #- fedora:41
-          - debian:12
+          - debian:13
           - ubuntu:24.04
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6
@@ -167,14 +170,14 @@ jobs:
       - name: Run install task manually for openvox-server
         env:
           PT_package: "openvox-server"
-          PT_version: "8.8.0"
+          PT_version: "8.12.0"
         run: ./openvox_bootstrap/tasks/install_linux.sh
       - name: Verify openvox-server is installed
-        run: /opt/puppetlabs/bin/puppetserver --version | grep '8.8.0'
+        run: /opt/puppetlabs/bin/puppetserver --version | grep '8.12.0'
       - name: Verify idempotency
         env:
           PT_package: "openvox-server"
-          PT_version: "8.8.0"
+          PT_version: "8.12.0"
         run: ./openvox_bootstrap/tasks/install_linux.sh
 
   test-downgrade:
@@ -183,10 +186,13 @@ jobs:
         image:
           - almalinux:8
           - almalinux:9
+          - almalinux:10
           - rockylinux:8
           - rockylinux:9
+          - rockylinux/rockylinux:10
           - debian:11
           - debian:12
+          - debian:13
           - fedora:43
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6

--- a/.github/workflows/pr_testing_configure.yaml
+++ b/.github/workflows/pr_testing_configure.yaml
@@ -31,13 +31,13 @@ jobs:
         os:
           - [almalinux, '9']
           - [ubuntu, '24.04']
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - id: install-bolt
         uses: ./.github/actions/bolt
         with:
-          os-codename: jammy
+          os-version: 24.04
       - id: vm-cluster
         uses: jpartlow/nested_vms@v1
         with:

--- a/.github/workflows/pr_testing_configure.yaml
+++ b/.github/workflows/pr_testing_configure.yaml
@@ -30,6 +30,8 @@ jobs:
       matrix:
         os:
           - [almalinux, '9']
+          - [rocky, '10']
+          - [debian, '13']
           - [ubuntu, '24.04']
     runs-on: ubuntu-24.04
     steps:
@@ -107,7 +109,7 @@ jobs:
           set -e
           csr_pem=$(cat)
           csr_text=$(openssl req -text <<<"$csr_pem")
-          password=$(awk -F: -e '/challengePassword/ { print $2 }' <<<"$csr_text")
+          password=$(awk -F: -- '/challengePassword/ { print $2 }' <<<"$csr_text")
           [[ "${password}" == 'password' ]]
           EOF
           bolt file upload sign.sh /etc/puppetlabs/puppet/sign.sh --inventory inventory.yaml --targets test-primary-1
@@ -121,8 +123,7 @@ jobs:
           chown puppet:puppet /etc/puppetlabs/puppet/sign.sh
 
           set +e
-          systemctl start puppetserver
-          if [ $? -ne 0 ]; then
+          if ! systemctl start puppetserver; then
             cat /var/log/puppetlabs/puppetserver/puppetserver.log
             exit 1
           fi

--- a/.github/workflows/pr_testing_install_build_artifact.yaml
+++ b/.github/workflows/pr_testing_install_build_artifact.yaml
@@ -36,11 +36,14 @@ jobs:
         image:
           - almalinux:8
           - almalinux:9
+          - almalinux:10
           - rockylinux:8
           - rockylinux:9
+          - rockylinux/rockylinux:10
           - debian:11
           - debian:12
-          - fedora:42
+          - debian:13
+          - fedora:43
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6
     runs-on: ubuntu-latest
@@ -54,18 +57,17 @@ jobs:
       - name: Run openvox-agent install task manually
         env:
           PT__installdir: ${{ github.workspace }}
-          PT_version: "8.15.0"
+          PT_version: "8.18.0"
         run: ./openvox_bootstrap/tasks/install_build_artifact_linux.sh
       - name: Verify openvox-agent is installed
-        shell: bash
         env:
           PT__installdir: ${{ github.workspace }}
-          PT_version: "8.15.0"
+          PT_version: "8.18.0"
         run: ./openvox_bootstrap/tasks/check_linux.sh
       - name: Verify idempotency
         env:
           PT__installdir: ${{ github.workspace }}
-          PT_version: "8.15.0"
+          PT_version: "8.18.0"
         run: ./openvox_bootstrap/tasks/install_build_artifact_linux.sh
 
   test-install-build-artifact-task-noarch:
@@ -73,14 +75,14 @@ jobs:
       matrix:
         package:
           - name: openvox-server
-            version: 8.8.0
+            version: 8.12.1
           - name: openvoxdb
-            version: 8.9.0
+            version: 8.12.1
           - name: openvoxdb-termini
-            version: 8.9.0
+            version: 8.12.1
         details:
-          - image: almalinux:9
-          - image: debian:12
+          - image: almalinux:10
+          - image: debian:13
           - image: ubuntu:24.04
     runs-on: ubuntu-latest
     container: ${{ matrix.details.image }}
@@ -93,7 +95,7 @@ jobs:
       - name: Run openvox-agent install task manually
         env:
           PT__installdir: ${{ github.workspace }}
-          PT_version: "8.19.1"
+          PT_version: "8.21.1"
         run: ./openvox_bootstrap/tasks/install_build_artifact_linux.sh
       - name: Test noarch package installation
         env:
@@ -101,7 +103,7 @@ jobs:
           PT_package: ${{ matrix.package.name }}
           PT_version: ${{ matrix.package.version }}
         run: ./openvox_bootstrap/tasks/install_build_artifact_linux.sh
-      - name: Verify openvox server component  is installed
+      - name: Verify openvox server component is installed
         shell: bash
         env:
           PACKAGE: ${{ matrix.package.name }}

--- a/.github/workflows/pr_testing_install_build_artifact.yaml
+++ b/.github/workflows/pr_testing_install_build_artifact.yaml
@@ -110,3 +110,48 @@ jobs:
           /opt/puppetlabs/bin/puppet resource package "${PACKAGE}" > openvox-package.status
           cat openvox-package.status
           grep "ensure.*=>.*'${VERSION}" openvox-package.status
+
+  test-downgrade:
+    strategy:
+      matrix:
+        image:
+          - almalinux:8
+          - almalinux:9
+          - almalinux:10
+          - rockylinux:8
+          - rockylinux:9
+          - rockylinux/rockylinux:10
+          - debian:11
+          - debian:12
+          - debian:13
+          - fedora:43
+          # Need to pull in the repo GPG keys for sles
+          #          - registry.suse.com/suse/sle15:15.6
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: openvox_bootstrap
+      - id: prep
+        uses: ./openvox_bootstrap/.github/actions/container_task_prep
+      - name: Run openvox-agent install task manually
+        env:
+          PT__installdir: ${{ github.workspace }}
+          PT_version: "8.25.0"
+        run: ./openvox_bootstrap/tasks/install_build_artifact_linux.sh
+      - name: Verify openvox-agent is installed
+        env:
+          PT__installdir: ${{ github.workspace }}
+          PT_version: "8.25.0"
+        run: ./openvox_bootstrap/tasks/check_linux.sh
+      - name: Install older version of agent
+        env:
+          PT__installdir: ${{ github.workspace }}
+          PT_version: "8.18.0"
+        run: ./openvox_bootstrap/tasks/install_build_artifact_linux.sh
+      - name: Verify openvox-agent is downgraded
+        env:
+          PT__installdir: ${{ github.workspace }}
+          PT_version: "8.18.0"
+        run: ./openvox_bootstrap/tasks/check_linux.sh

--- a/.github/workflows/pr_testing_install_build_artifact.yaml
+++ b/.github/workflows/pr_testing_install_build_artifact.yaml
@@ -13,19 +13,16 @@ jobs:
   test-install-build-artifact-task-on-ubuntu:
     strategy:
       matrix:
-        os-details:
-          - os: ubuntu-22.04
-            codename: jammy
-    #      - os: ubuntu-24.04
-    #        codename: noble
-    # Perforce hasn't yet released bolt on 24.04.
-    runs-on: ${{ matrix.os-details.os }}
+        os-version:
+          - 22.04
+          - 24.04
+    runs-on: ${{ format('ubuntu-{0}', matrix.os-version) }}
     steps:
       - uses: actions/checkout@v4
       - id: install-bolt
         uses: ./.github/actions/bolt
         with:
-          os-codename: ${{ matrix.os-details.codename }}
+          os-version: ${{ matrix.os-version }}
       - name: Run openvox-agent install task
         run: bolt task run openvox_bootstrap::install_build_artifact version=8.15.0 --targets localhost --run-as root
       - name: Verify openvox-agent is installed
@@ -44,7 +41,6 @@ jobs:
           - debian:11
           - debian:12
           - fedora:42
-          - ubuntu:24.04
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_testing_with_nested_vms.yml
+++ b/.github/workflows/pr_testing_with_nested_vms.yml
@@ -26,13 +26,13 @@ jobs:
           - [ubuntu, '20.04']
           - [ubuntu, '22.04']
           - [ubuntu, '24.04']
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - id: install-bolt
         uses: ./.github/actions/bolt
         with:
-          os-codename: jammy
+          os-version: 24.04
       - id: vm-cluster
         uses: jpartlow/nested_vms@v1
         with:
@@ -81,13 +81,13 @@ jobs:
           - [debian, '12']
           - [rocky, '9']
           - [ubuntu, '24.04']
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - id: install-bolt
         uses: ./.github/actions/bolt
         with:
-          os-codename: jammy
+          os-version: 24.04
       - id: vm-cluster
         uses: jpartlow/nested_vms@v1
         with:

--- a/.github/workflows/pr_testing_with_nested_vms.yml
+++ b/.github/workflows/pr_testing_with_nested_vms.yml
@@ -17,11 +17,13 @@ jobs:
         os:
           - [almalinux, '8']
           - [almalinux, '9']
+          - [almalinux, '10']
           - [debian, '11']
           - [debian, '12']
-          - [debian, '13', 'amd64', 'daily-latest']
+          - [debian, '13']
           - [rocky, '8']
           - [rocky, '9']
+          - [rocky, '10']
           - [ubuntu, '18.04']
           - [ubuntu, '20.04']
           - [ubuntu, '22.04']
@@ -78,8 +80,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - [debian, '12']
-          - [rocky, '9']
+          - [debian, '13']
+          - [rocky, '10']
           - [ubuntu, '24.04']
     runs-on: ubuntu-24.04
     steps:

--- a/files/common.sh
+++ b/files/common.sh
@@ -219,6 +219,40 @@ get_deb_package_version() {
   echo -n "${_package_version}"
 }
 
+# Install an rpm package, either from a local file or from the
+# repository using the best available package manager interface.
+#
+# In descending preference, checks for dnf, yum and zypper.
+#
+# Downgrades are implicitly accepted when dnf/yum are used and a
+# version is specified. I'm not certain about zypper's behavior yet.
+install_rpm() {
+  if exists 'dnf'; then
+    exec_and_capture dnf install --assumeyes "$@"
+  elif exists 'yum'; then
+    exec_and_capture yum install --assumeyes "$@"
+  elif exists 'zypper'; then
+    exec_and_capture zypper install --non-interactive "$@"
+  else
+    fail "Unable to install $*. Neither dnf, yum nor zypper are installed."
+  fi
+}
+
+# Install a deb package, either from a local file or from the
+# repository using the best available package manager interface.
+#
+# Prefers apt-get to apt, since apt is really meant for interactive
+# use.
+install_deb() {
+  if exists 'apt-get'; then
+    exec_and_capture apt-get install --yes "$@"
+  elif exists 'apt'; then
+    exec_and_capture apt install --yes "$@"
+  else
+    fail "Unable to install $*. Neither apt nor apt-get are installed."
+  fi
+}
+
 # Install a local rpm or deb package file.
 install_package_file() {
   local _package_file="$1"
@@ -229,10 +263,17 @@ install_package_file() {
   case $_package_type in
     rpm)
       # can switch to dnf when we drop amazon 2 support
-      yum install --assumeyes "$_package_file"
+      install_rpm "$_package_file"
       ;;
     deb)
-      apt install --yes "$_package_file"
+      # Specifying --allow-downgrades here avoids an irritating bug
+      # with apt where the openvox-agent pins in the openvox release
+      # package seemingly cause a repeat call of `apt-get install
+      # ./local.rpm` to fail due to apt considering it a downgrade
+      # despite the version being identical. This was a problem for
+      # idempotency of install_build_artifact task calls when the
+      # release package was also installed.
+      install_deb --allow-downgrades "$_package_file"
       ;;
     *)
       fail "Unhandled package type: '${package_type}'"
@@ -257,10 +298,15 @@ install_package() {
     _os_full_version="${os_full_version}"
   fi
 
+  local _allow_downgrades
   local _package_and_version
   if [[ -n "${_version}" ]] && [[ "${_version}" != 'latest' ]]; then
     case $_os_family in
       debian|ubuntu)
+        # dnf/yum implicitly allow downgrades when a version is
+        # specified, but apt/apt-get do not, so we need to explicitly
+        # specify that here.
+        _allow_downgrades='--allow-downgrades'
         local _deb_package_version
         _deb_package_version=$(get_deb_package_version "${_version}" "${_os_family}" "${_os_full_version}")
         _package_and_version="${_package}=${_deb_package_version}"
@@ -275,24 +321,16 @@ install_package() {
 
   case ${_os_family} in
     debian|ubuntu)
-      if exists 'apt-get'; then
-        exec_and_capture apt-get install -y "${_package_and_version}"
-      elif exists 'apt'; then
-        exec_and_capture apt install -y "${_package_and_version}"
-      else
-        fail "Unable to install ${_package}. Neither apt nor apt-get are installed."
-      fi
+      # _allow_downgrades is unquoted here because it is either an
+      # empty string or the string '--allow-downgrades', and
+      # Shellcheck seems smart enough to recognize that this is ok.
+      # Leaving it unquoted prevents it from being passed as an empty
+      # argument when it is an empty string, and avoids an extra space
+      # when $* is evaluated.
+      install_deb ${_allow_downgrades} "${_package_and_version}"
       ;;
     *)
-      if exists 'dnf'; then
-        exec_and_capture dnf install -y "${_package_and_version}"
-      elif exists 'yum'; then
-        exec_and_capture yum install -y "${_package_and_version}"
-      elif exists 'zypper'; then
-        exec_and_capture zypper install -y "${_package_and_version}"
-      else
-        fail "Unable to install ${_package}. Neither dnf, yum nor zypper are installed."
-      fi
+      install_rpm "${_package_and_version}"
       ;;
   esac
 }

--- a/files/common.sh
+++ b/files/common.sh
@@ -51,12 +51,11 @@ exists() {
 #
 # so that the caller can inspect them as well.
 exec_and_capture() {
-  local _cmd="$*"
+  info "Executing: $*"
 
-  info "Executing: ${_cmd}"
 
   set +e
-  LAST_EXEC_AND_CAPTURE_OUTPUT=$(${_cmd} 2>&1)
+  LAST_EXEC_AND_CAPTURE_OUTPUT=$("$@" 2>&1)
   LAST_EXEC_AND_CAPTURE_STATUS=$?
   set -e
 

--- a/files/common.sh
+++ b/files/common.sh
@@ -53,11 +53,17 @@ exists() {
 exec_and_capture() {
   info "Executing: $*"
 
+  local _restore_errexit=false
+  if [[ "$-" == *e* ]]; then
+    _restore_errexit=true
+  fi
 
   set +e
   LAST_EXEC_AND_CAPTURE_OUTPUT=$("$@" 2>&1)
   LAST_EXEC_AND_CAPTURE_STATUS=$?
-  set -e
+  if ${_restore_errexit}; then
+    set -e
+  fi
 
   echo "${LAST_EXEC_AND_CAPTURE_OUTPUT}"
   info "Status: ${LAST_EXEC_AND_CAPTURE_STATUS}"

--- a/spec/unit/bash/common_sh_spec.rb
+++ b/spec/unit/bash/common_sh_spec.rb
@@ -253,7 +253,7 @@ describe 'files/common.sh' do
       it 'installs a package' do
         output, status = test('install_package foo')
 
-        expect(output).to include('apt-get given: install -y foo')
+        expect(output).to include('apt-get given: install --yes foo')
         expect(status.success?).to be(true)
       end
 
@@ -261,14 +261,14 @@ describe 'files/common.sh' do
         output, status = test('install_package foo 1.2.3')
 
         expect(status.success?).to be(true)
-        expect(output).to include('apt-get given: install -y foo=1.2.3-1+ubuntu24.04')
+        expect(output).to include('apt-get given: install --yes --allow-downgrades foo=1.2.3-1+ubuntu24.04')
       end
 
       it 'installs a deb with full package version given' do
         output, status = test('install_package foo 1.2.3-1something')
 
         expect(status.success?).to be(true)
-        expect(output).to include('apt-get given: install -y foo=1.2.3-1something')
+        expect(output).to include('apt-get given: install --yes --allow-downgrades foo=1.2.3-1something')
       end
 
       it 'fails if package manager fails' do
@@ -283,14 +283,14 @@ describe 'files/common.sh' do
         expect(output).to include('apt-get failed')
       end
 
-      it 'falls back to apt-get' do
+      it 'falls back to apt' do
         behave_as_if_command_does_not_exist('apt-get')
         allow_script.to receive_command(:apt).and_exec('echo "apt given: $*"')
 
         output, status = test('install_package foo')
 
         expect(status.success?).to be(true)
-        expect(output).to include('apt given: install -y foo')
+        expect(output).to include('apt given: install --yes foo')
       end
 
       it 'fails if neither apt nor apt-get are available' do
@@ -316,14 +316,14 @@ describe 'files/common.sh' do
         output, status = test('install_package foo')
 
         expect(status.success?).to be(true)
-        expect(output).to include('dnf given: install -y foo')
+        expect(output).to include('dnf given: install --assumeyes foo')
       end
 
       it 'installs a package with a version' do
         output, status = test('install_package foo 1.2.3')
 
         expect(status.success?).to be(true)
-        expect(output).to include('dnf given: install -y foo-1.2.3')
+        expect(output).to include('dnf given: install --assumeyes foo-1.2.3')
       end
 
       it 'fails if package manager fails' do
@@ -345,7 +345,7 @@ describe 'files/common.sh' do
         output, status = test('install_package foo')
 
         expect(status.success?).to be(true)
-        expect(output).to include('yum given: install -y foo')
+        expect(output).to include('yum given: install --assumeyes foo')
       end
 
       it 'fails if dnf, yum and zypper are all unavailable' do

--- a/spec/unit/bash/common_sh_spec.rb
+++ b/spec/unit/bash/common_sh_spec.rb
@@ -139,6 +139,25 @@ describe 'files/common.sh' do
       expect(output).to include('arg1=hello world')
       expect(output).to include('arg2=foo bar')
     end
+
+    it 'preserves errexit behavior' do
+      output, status = test(<<~EOS)
+        set -e
+        fail() {
+          echo "failing"
+          return 1
+        }
+        exec_and_capture fail
+        echo "This should not be printed"
+      EOS
+
+      expect(status.success?).to be(false)
+      expect(output).to eq(<<~EOS)
+        ts [INFO]: Executing: fail
+        failing
+        ts [INFO]: Status: 1
+      EOS
+    end
   end
 
   context 'download()' do

--- a/spec/unit/bash/common_sh_spec.rb
+++ b/spec/unit/bash/common_sh_spec.rb
@@ -125,6 +125,20 @@ describe 'files/common.sh' do
         LAST_EXEC_AND_CAPTURE_STATUS=0
       EOS
     end
+
+    it 'preserves arguments with spaces' do
+      output, status = test(<<~EOS)
+        check_args() {
+          echo "arg1=$1"
+          echo "arg2=$2"
+        }
+        exec_and_capture check_args "hello world" "foo bar"
+      EOS
+
+      expect(status.success?).to be(true)
+      expect(output).to include('arg1=hello world')
+      expect(output).to include('arg2=foo bar')
+    end
   end
 
   context 'download()' do


### PR DESCRIPTION
There are several related commits in this PR.

Broadly this change ensures that apt package management behaves the same
as dnf/yum when a version is specified. The later will downgrade to the
given version, if needed, implicitly. But apt requires that
--allow-downgrades is set or it will error. The patched code provides
--allow-downgrades to apt where needed to avoid erroring out and to match
the dnf/yum behavior.

This change also works around an apt bug where repeat calls to
install a deb file of the same version would fail citing a need to
downgrade when the openvox release package was also installed. (Possibly
due to the openvox-agent pins in the release package? Unclear...)

Finally, helper functions install_rpm() and install_deb() are extracted
from install_package() to ensure consistent behavior between
install_package_file() and install_package(). Previously,
install_package_file() would only use yum or apt, rather than preferring
dnf and apt-get respectively, and was not working through
exec_and_capture, there by losing the logging of the command call.

---

Previously we were stuck running on Ubuntu 22.04 vms and installing the older Perforce Bolt package. Now that the Openvox Bolt package is available, testing on 24.04 vms is possible and the bolt action installs openbolt from the Openvox repository instead. This change is what exposed the bug above.

---

Also patches  a bug in the common.sh exec_and_capture() function which would
have caused arguments with spaces to have eventually be evaluated
separately. Something like 'exec_and_capture foo "bar and baz"'
would have executed in the subshell as 'foo bar and baz' (foo called
with three args, 'bar', 'and', 'baz', rather than a single 'bar and baz'
argument). We weren't making calls that should have exposed this, but
it's better to patch the problem anyway.

---

Finally, updates the test coverage to provide el-10, fedora 43 and more general debian 13 coverage.
