### PR TITLE
Add Ubuntu 26.04 to gha nested_vms workflow

### DIFF
--- a/.github/workflows/pr_testing_with_nested_vms.yml
+++ b/.github/workflows/pr_testing_with_nested_vms.yml
@@ -24,10 +24,10 @@ jobs:
           - [rocky, '8']
           - [rocky, '9']
           - [rocky, '10']
-          - [ubuntu, '18.04']
           - [ubuntu, '20.04']
           - [ubuntu, '22.04']
           - [ubuntu, '24.04']
+          - [ubuntu, '26.04']
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Adds it to the testing matrix for nested_vms now that kvm_automation_tooling 2.7.0 supports 26.04. Drops 18.04 which is several years eol.

Does not add it to any of the other workflows since Github has not yet released a 26.04 runner.