### PR TITLE
(ci) Add arm64 vms to the test matrices

### DIFF
--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -28,10 +28,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner-suffix:
+          - ''
+          - '-arm'
         os-version:
           - 22.04
           - 24.04
-    runs-on: ${{ format('ubuntu-{0}', matrix.os-version) }}
+    runs-on: ${{ format('ubuntu-{0}{1}', matrix.os-version, matrix.runner-suffix) }}
     needs: shellcheck
     steps:
       - uses: actions/checkout@v6
@@ -57,6 +60,9 @@ jobs:
   test-install-task-on-other-os-via-containers:
     strategy:
       matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
         image:
           - almalinux:8
           - almalinux:9
@@ -71,7 +77,7 @@ jobs:
           # Need to pull in the repo GPG keys for sles
           #          - registry.suse.com/suse/sle15:15.6
     needs: shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     container: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_testing_configure.yaml
+++ b/.github/workflows/pr_testing_configure.yaml
@@ -48,21 +48,18 @@ jobs:
           os-version: ${{ matrix.os[1] }}
           os-arch: ${{ matrix.os[2] || 'x86_64' }}
           host-root-access: true
-          ruby-version: '3.3'
           install-openvox: false
           vms: |-
             [
               {
                 "role": "primary",
                 "cpus": 4,
-                "mem_mb": 8192,
-                "cpu_mode": "host-model"
+                "mem_mb": 8192
               },
               {
                 "role": "agent",
                 "cpus": 2,
-                "mem_mb": 4096,
-                "cpu_mode": "host-model"
+                "mem_mb": 4096
               }
             ]
       - name: Capture dereferenced inventory for use with openvox_bootstrap

--- a/.github/workflows/pr_testing_with_nested_vms.yml
+++ b/.github/workflows/pr_testing_with_nested_vms.yml
@@ -14,6 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - x86_64
+          - aarch64
         os:
           - [almalinux, '8']
           - [almalinux, '9']
@@ -24,10 +27,16 @@ jobs:
           - [rocky, '8']
           - [rocky, '9']
           - [rocky, '10']
-          - [ubuntu, '20.04']
           - [ubuntu, '22.04']
           - [ubuntu, '24.04']
           - [ubuntu, '26.04']
+        exclude:
+          - arch: aarch64
+            os: [ubuntu, '22.04']
+          - arch: aarch64
+            os: [ubuntu, '24.04']
+          - arch: aarch64
+            os: [ubuntu, '26.04']
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -40,24 +49,17 @@ jobs:
         with:
           os: ${{ matrix.os[0] }}
           os-version: ${{ matrix.os[1] }}
-          os-arch: ${{ matrix.os[2] || 'x86_64' }}
-          image_version: ${{ matrix.os[3] }}
+          os-arch: ${{ matrix.arch }}
+          image_version: ${{ matrix.os[2] }}
           host-root-access: true
-          ruby-version: '3.3'
           install-openvox: false
-          # Note: the cpu_mode is set to host-model for the sake of
-          # el-9 which expects at least x86_64-2 arch. This depends on
-          # the runner's architecture being sufficient, and there is
-          # probably a better way to get this set on the libvirt
-          # domain instead.
           vms: |-
             [
               {
                 "role": "agent",
                 "count": 1,
                 "cpus": 2,
-                "mem_mb": 4096,
-                "cpu_mode": "host-model"
+                "mem_mb": 4096
               }
             ]
       - name: Capture dereferenced inventory for use with openvox_bootstrap
@@ -79,10 +81,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - x86_64
+          - aarch64
         os:
           - [debian, '13']
           - [rocky, '10']
           - [ubuntu, '24.04']
+        exclude:
+          - arch: aarch64
+            os: [ubuntu, '24.04']
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -95,24 +103,17 @@ jobs:
         with:
           os: ${{ matrix.os[0] }}
           os-version: ${{ matrix.os[1] }}
-          os-arch: ${{ matrix.os[2] || 'x86_64' }}
-          image_version: ${{ matrix.os[3] }}
+          os-arch: ${{ matrix.arch }}
+          image_version: ${{ matrix.os[2] }}
           host-root-access: true
-          ruby-version: '3.3'
           install-openvox: false
-          # Note: the cpu_mode is set to host-model for the sake of
-          # el-9 which expects at least x86_64-2 arch. This depends on
-          # the runner's architecture being sufficient, and there is
-          # probably a better way to get this set on the libvirt
-          # domain instead.
           vms: |-
             [
               {
                 "role": "agent",
                 "count": 1,
                 "cpus": 2,
-                "mem_mb": 4096,
-                "cpu_mode": "host-model"
+                "mem_mb": 4096
               }
             ]
       - name: Capture dereferenced inventory for use with openvox_bootstrap


### PR DESCRIPTION
Tests openvox_bootstrap::install on arm64 vms.
Skips ubuntu on arm64 because they are very slow under qemu.
Drops specifying ruby-version, since nested_vms is on 3.4 as of 1.4.0.
Drops cpu_mode in vm definitions since kvm_automation_tooling will
handle that as of 2.8.0.
Drops ubuntu 20.04 from the test matrix since it is eol.